### PR TITLE
Fixed NaN% volume and also made sounds actually play again

### DIFF
--- a/Settings.jsx
+++ b/Settings.jsx
@@ -88,12 +88,12 @@ module.exports = class Settings extends React.Component {
                 </div>
                 <div className='nf-slider-container nf-setting-value'>
                   <SliderInput
-                    initialValue={this.state.notifsounds[sound] ? this.state.notifsounds[sound].volume * 100 : 50}
+                    initialValue={this.state.notifsounds[sound] ? (this.state.notifsounds[sound].volume || 0.5) * 100 : 50}
                     minValue={0}
                     maxValue={100}
                     className='nf-slider'
                     // onMarkerRender={marker => `${marker} ${Messages.SMART_TYPERS.USERS}`}
-                    defaultValue={this.state.notifsounds[sound] ? this.state.notifsounds[sound].volume * 100 : 50}
+                    defaultValue={this.state.notifsounds[sound] ? (this.state.notifsounds[sound].volume || 0.5) * 100 : 50}
                     onValueChange={_.debounce((value) => {
                       if (!this.state.notifsounds[sound]) {
                         this.state.notifsounds[sound] = {};
@@ -110,6 +110,7 @@ module.exports = class Settings extends React.Component {
                         this.state.notifsounds[sound] = {};
                       }
                       this.state.notifsounds[sound].url = value;
+                      this.state.notifsounds[sound].volume = this.state.notifsounds[sound].volume || 0.5;
                       if (this.state.notifsounds[sound].url === '') {
                         delete this.state.notifsounds[sound];
                       }

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ module.exports = class NotificationSounds extends Plugin {
     const isDisabled = await getModule([ 'isSoundDisabled' ]);
     const getCurrentUser = await getModule([ 'getCurrentUser' ]);
     const { getCalls } = await getModule([ 'getCalls' ]);
+
+    const settings = powercord.api.settings.buildCategoryObject('ringtoner'); // This fixes... quite a lot for whatever reason
+
     const play = (type) => {
       const audio = new Audio();
       audio.pause();
@@ -54,7 +57,7 @@ module.exports = class NotificationSounds extends Plugin {
       playing[type] = audio;
     };
     inject('ns-playSound', SoundPlayer, 'playSound', (e) => {
-      this.custom = this.settings.get('notifsounds', false);
+      this.custom = settings.get('notifsounds', false);
       if (this.custom[e[0]] && this.custom[e[0]].url) {
         play(e[0]);
         return false;
@@ -70,7 +73,7 @@ module.exports = class NotificationSounds extends Plugin {
      * }, false);
      */
     inject('ns-call', CallHandler, 'handleRingUpdate', (e) => {
-      this.custom = this.settings.get('notifsounds', false);
+      this.custom = settings.get('notifsounds', false);
       const call = getCalls().filter((x) => x.ringing.length > 0);
       if (call[0]) {
         if (call[0].ringing[0] === getCurrentUser.getCurrentUser().id && this.custom.call_ringing) {


### PR DESCRIPTION
The volume whenever placing in a custom sound would display NaN% volume, this was caused by the fact that for whatever reason the volume wasn't saved into the config.

The sounds also weren't playing when I was using it (this was occurring due to `this.settings.getKeys()` being empty, for reasons I have no clue of), so that was fixed too.