### PR TITLE
Add the ability to use local files as a notification sound.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,14 @@ module.exports = class NotificationSounds extends Plugin {
     const play = (type) => {
       const audio = new Audio();
       audio.pause();
-      audio.src = this.custom[type].url;
+      if (this.custom[type].url.startsWith('http')) {
+        audio.src = this.custom[type].url;
+      } else {
+        fs.readFile(this.custom[type].url, (err, data) => {
+          if (err) console.log(err);
+          else audio.src = ('data:audio/mpeg;base64,'+data.toString('base64')); 
+        });
+      }
       audio.volume = this.custom[type].volume ?? 0.5;
       audio.play();
     };
@@ -50,7 +57,14 @@ module.exports = class NotificationSounds extends Plugin {
       }
       const audio = new Audio();
       audio.pause();
-      audio.src = this.custom[type].url;
+      if (this.custom[type].url.startsWith('http')) {
+        audio.src = this.custom[type].url;
+      } else {
+        fs.readFile(this.custom[type].url, (err, data) => {
+          if (err) console.log(err);
+          else audio.src = ('data:audio/mpeg;base64,'+data.toString('base64')); 
+        });
+      }
       audio.loop = true;
       audio.volume = this.custom[type].volume ?? 0.5;
       audio.play();


### PR DESCRIPTION
Implements the feature suggested in #6.

NOTE: This is terrible because, unless there is magic I don't know about, every time a sound is needed from a file, device storage will be read. I just didn't want to make too drastic of a change to already existing code; I feel that that'd be pretty rude.