### PR TITLE
Fix message sounds

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ module.exports = class NotificationSounds extends Plugin {
     inject('ns-showNotificationPre', showNotification, 'showNotification', (args) => {
       if (args.length >= 4) {
         const info = args[3];
-        if (info.sound.startsWith('message') && this.custom['message1']) {
+        if (!!info.sound && info.sound.startsWith('message') && this.custom['message1'] && !info.isReplacedByNSC) {
           return [ args[0], args[1], args[2], Object.assign(info, { playSoundIfDisabled: false, sound: null, isReplacedByNSC: true }) ];
         }
       }

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = class NotificationSounds extends Plugin {
 
     inject('ns-playSound', SoundPlayer, 'playSound', (e) => {
       this.custom = settings.get('notifsounds', false);
-      console.log(e);
+      //console.log(e);
       if (this.custom[e[0]] && this.custom[e[0]].url) {
         play(e[0]);
         return false;

--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ module.exports = class NotificationSounds extends Plugin {
 
     // Prevent message sounds from playing by overwriting the 4th argument.
     inject('ns-showNotificationPre', showNotification, 'showNotification', (args) => {
-      console.log(args)
       if (args.length >= 4) {
         const info = args[3];
         if (info.sound.startsWith('message') && this.custom['message1']) {


### PR DESCRIPTION
Message sounds were previously broken for some reason, but they would work perfectly fine over the "Notifications" and the plugin's Settings page. The current solution is most likely ultimately temporary, however this may also open up the possibility of making #5 work.